### PR TITLE
제품목록 페이지에서 제품상세페이지로 이동 구현

### DIFF
--- a/src/api/shopApi.js
+++ b/src/api/shopApi.js
@@ -1,0 +1,16 @@
+import { phonecaseProducts } from "../dummydata/phonecaseProducts";
+
+export const getList = () => {
+  // todo: 페이지네이션
+  // const { page, size } = pageParam;
+  // const res = await axios.get(`${prefix}/list`, { params: { page, size } });
+  // return res.data;
+  const data = phonecaseProducts;
+  return data;
+};
+
+export const getOne = (productId) => {
+  //   const res = await axios.get(`${prefix}/${tno}`);
+  //   return res.data;
+  return phonecaseProducts.find((p) => p.id == productId);
+};

--- a/src/components/phonecase/DetailComponent.js
+++ b/src/components/phonecase/DetailComponent.js
@@ -1,8 +1,20 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { phonecaseProducts } from "../../dummydata/phonecaseProducts";
+import { useParams } from "react-router-dom";
+import { getOne } from "../../api/shopApi";
 
 const DetailComponent = () => {
-  const imageSrc = phonecaseProducts[3].image;
+  const { productId } = useParams();
+  const [product, setProduct] = useState({
+    id: 0,
+    name: "",
+    price: 0,
+    image: "",
+  });
+
+  useEffect(() => {
+    setProduct(getOne(productId));
+  }, []);
 
   return (
     <div className="p-6 space-y-10">
@@ -10,13 +22,15 @@ const DetailComponent = () => {
       <div className="flex flex-col md:flex-row gap-8">
         {/* 왼쪽: 대표 이미지 */}
         <div className="flex-1 flex justify-center items-center border rounded-lg p-4">
-          <img src={imageSrc} alt="상품 이미지" className="object-cover" />
+          <img src={product.image} alt="상품 이미지" className="object-cover" />
         </div>
 
         {/* 오른쪽: 상세 정보 */}
         <div className="flex-1 space-y-4">
-          <h1 className="text-2xl font-bold">상품명 (Phone Case C)</h1>
-          <p className="text-xl text-red-500 font-semibold">판매가: 12,000원</p>
+          <h1 className="text-2xl font-bold">상품명 {product.name}</h1>
+          <p className="text-xl text-red-500 font-semibold">
+            판매가: {product.price}원
+          </p>
           <p className="text-gray-600">제조사: OO컴퍼니</p>
           <p className="text-gray-600">원산지: 대한민국</p>
           <p className="text-gray-600">배송비: 3,000원</p>
@@ -46,7 +60,7 @@ const DetailComponent = () => {
       {/* 제품상세 이미지 */}
       <div className="border rounded-lg p-4">
         <img
-          src={imageSrc}
+          src={product.image}
           alt="제품 상세 이미지"
           className="w-full object-cover"
         />

--- a/src/components/phonecase/ListComponent.js
+++ b/src/components/phonecase/ListComponent.js
@@ -1,25 +1,60 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { phonecaseProducts } from "../../dummydata/phonecaseProducts";
+import { getList } from "../../api/shopApi";
+import { useNavigate } from "react-router-dom";
 
 const ListComponent = () => {
-  const dummyProducts = phonecaseProducts;
+  const navigate = useNavigate();
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    // 백엔드가 있다면 이런식으로
+    // getList({ page, size }).then((da) => {
+    //   setServerData(da);
+    // });
+    const data = getList();
+    setProducts(data);
+  }, []);
+
+  const addClickHandler = () => {
+    setProducts((prev) => [
+      {
+        id: 9,
+        name: "Phone Case I",
+        price: 21000,
+        image:
+          "https://akan.co.kr/upload/products/NEVER/JINN5007/thumb-single-graybg.webp",
+      },
+      ...prev,
+    ]);
+  };
+
+  const moveToDetailHandler = (e, productId) => {
+    e.preventDefault();
+
+    navigate(`/phonecase/${productId}`);
+  };
 
   return (
     <div className="p-6 space-y-6">
+      <button onClick={addClickHandler}>
+        상품 추가 버튼(더미데이터 테스트)
+      </button>
       {/* 상단 전체 개수 */}
-      <div className="text-lg font-semibold">전체 50개</div>
+      <div className="text-lg font-semibold">전체 30개</div>
 
       {/* 상품 목록 */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        {dummyProducts.map((product) => (
+        {products.map((product) => (
           <div
             key={product.id}
-            className="border rounded-lg shadow-sm hover:shadow-md transition p-4 flex flex-col items-center"
+            onClick={(e) => moveToDetailHandler(e, product.id)}
+            className="border rounded-lg shadow-sm hover:shadow-md transition p-4 flex flex-col items-center cursor-pointer"
           >
             <img
               src={product.image}
               alt={product.name}
-              className="w-24 h-24 object-cover mb-3"
+              className="w-24 h-24 object-cover mb-3 "
             />
             <div className="text-base font-medium">{product.name}</div>
             <div className="text-sm text-gray-600">

--- a/src/dummydata/phonecaseProducts.js
+++ b/src/dummydata/phonecaseProducts.js
@@ -2,58 +2,212 @@
 export const phonecaseProducts = [
   {
     id: 1,
-    name: "Phone Case A",
-    price: 12000,
+    name: "나만의 커스텀 방탄케이스",
+    price: 9000,
+    image:
+      "https://akan.co.kr/upload/products/NEVER/AN9999/thumb-single-graybg.webp",
+  },
+  {
+    id: 2,
+    name: "그려용 커스텀 방탄케이스",
+    price: 10000,
     image:
       "https://akan.co.kr/upload/products/NEVER/KN0284/thumb-single-graybg.webp",
   },
   {
-    id: 2,
-    name: "Phone Case B",
-    price: 15000,
+    id: 3,
+    name: "늘어지냥 커스텀 방탄케이스",
+    price: 11000,
     image:
       "https://akan.co.kr/upload/products/NEVER/KYJN5004/thumb-single-graybg.webp",
   },
   {
-    id: 3,
-    name: "Phone Case C",
-    price: 18000,
+    id: 4,
+    name: "백설공주와엘리스 커스텀 방탄케이스",
+    price: 11000,
     image:
       "https://akan.co.kr/upload/products/NEVER/LSRN0001/thumb-single-graybg.webp",
   },
   {
-    id: 4,
-    name: "Phone Case D",
-    price: 20000,
+    id: 5,
+    name: "엘리스와 백설공주 커스텀 방탄케이스",
+    price: 11000,
     image:
       "https://akan.co.kr/upload/products/NEVER/LSRN5013/thumb-single-graybg.webp",
   },
   {
-    id: 1,
-    name: "Phone Case E",
-    price: 12000,
+    id: 6,
+    name: "AK판다 커스텀 방탄케이스",
+    price: 10000,
     image:
       "https://akan.co.kr/upload/products/NEVER/AN0016/thumb-single-graybg.webp",
   },
   {
-    id: 2,
-    name: "Phone Case F",
-    price: 15000,
+    id: 7,
+    name: "코기궁디 커스텀 방탄케이스",
+    price: 11000,
     image:
       "https://akan.co.kr/upload/products/NEVER/KN0016/thumb-single-graybg.webp",
   },
   {
-    id: 3,
-    name: "Phone Case G",
-    price: 18000,
+    id: 8,
+    name: "러브문 커스텀 방탄케이스",
+    price: 12000,
     image:
       "https://akan.co.kr/upload/products/NEVER/OHJN5013/thumb-single-graybg.webp",
   },
   {
-    id: 4,
-    name: "Phone Case H",
-    price: 20000,
+    id: 9,
+    name: "Dinosaur 커스텀 방탄케이스",
+    price: 10000,
     image:
       "https://akan.co.kr/upload/products/NEVER/KN0043/thumb-single-graybg.webp",
+  },
+  {
+    id: 10,
+    name: "아슬아슬 커스텀 방탄케이스",
+    price: 10000,
+    image:
+      "https://akan.co.kr/upload/products/NEVER/KN0291/thumb-single-graybg.webp",
+  },
+  {
+    id: 11,
+    name: "단 스마일 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/SJKF5030/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 12,
+    name: "다이노소어 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/KF0229/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 13,
+    name: "데이지꽃 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/EF5021/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 14,
+    name: "Tiger&Flower 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/YJEF0001/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 15,
+    name: "쿨쿨잠 미니미친구2 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/CCJF5037/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 16,
+    name: "AK판다 커스텀 방탄케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/NEVER/AN0016/thumb-single-graybg.webp",
+  },
+  {
+    id: 17,
+    name: "블랙커플 커스텀 인서트케이스",
+    price: 16000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/EF5042/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 18,
+    name: "삐약이 삼형제 커스텀 인서트케이스",
+    price: 15500,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/KF0215/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 19,
+    name: "자판기 커스텀 인서트케이스",
+    price: 17000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/KF0172/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 20,
+    name: "유칼립투스 커스텀 인서트케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/PHARD/ANOF5007/thumb-single-graybgnc.webp",
+  },
+  {
+    id: 21,
+    name: "밤의유령들 커스텀 하드켕스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/HMHH0003/thumb-single-graybg.webp",
+  },
+  {
+    id: 22,
+    name: "심플베어베어 커스텀 하드케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/UH5013/thumb-single-graybg.webp",
+  },
+  {
+    id: 23,
+    name: "Check 커스텀 하드케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/KH0173/thumb-single-graybg.webp",
+  },
+  {
+    id: 24,
+    name: "봄냥이 커스텀 하드케이스",
+    price: 16000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/UH5001/thumb-single-graybg.webp",
+  },
+  {
+    id: 25,
+    name: "큰나무 커스텀 하드케이스",
+    price: 15000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/ZSEH5249/thumb-single-graybg.webp",
+  },
+  {
+    id: 26,
+    name: "키위 커스텀 하드케이스",
+    price: 16000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/ZSEH5222/thumb-single-graybg.webp",
+  },
+  {
+    id: 27,
+    name: "fleur de reve 커스텀 하드케이스",
+    price: 17000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/BMRH5009/thumb-single-graybg.webp",
+  },
+  {
+    id: 28,
+    name: "멀바시바 커스텀 하드케이스",
+    price: 16000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/KH0221/thumb-single-graybg.webp",
+  },
+  {
+    id: 29,
+    name: "고래의 일생 커스텀 하드케이스",
+    price: 17000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/YHMH5020/thumb-single-graybg.webp",
+  },
+  {
+    id: 30,
+    name: "인연 커스텀 하드케이스",
+    price: 17000,
+    image:
+      "https://akan.co.kr/upload/products/HARD/UIDH5003/thumb-single-graybg.webp",
   },
 ];

--- a/src/router/root.js
+++ b/src/router/root.js
@@ -17,7 +17,7 @@ const root = createBrowserRouter([
     element: <ListPage></ListPage>,
   },
   {
-    path: "detail",
+    path: "phonecase/:productId",
     element: <DetailPage></DetailPage>,
   },
   {


### PR DESCRIPTION
- 제품목록에서 제품을 클릭시 제품상세 페이지로 navigate 를 이용하여 이동하도록 함
- ListComponent 에서 dummy 데이터를 이용해보기 위해 임시 테스트 코드 추가함
- root.js 의 제품상세 페이지로 가는 path: 를 "detail" 에서 "phonecase:/productId"로 수정